### PR TITLE
fix: ORDER BY id in _get_scalar_relation_map

### DIFF
--- a/src/read.jl
+++ b/src/read.jl
@@ -591,7 +591,11 @@ function _get_scalar_relation_map(
     )
     attribute = _get_attribute(db, collection_from, attribute_on_collection_from)
 
-    query = "SELECT $(attribute.id) FROM $(attribute.table_where_is_located)"
+    # ORDER BY id so the result aligns with source rows in id order. Without
+    # it, SQLite is free to pick an index-driven scan when a covering index
+    # exists on the FK column, which traverses rows in FK-value order and
+    # shuffles the returned vector. See psrenergy/PSRDatabase.jl#23.
+    query = "SELECT $(attribute.id) FROM $(attribute.table_where_is_located) ORDER BY id"
     df = DBInterface.execute(db.sqlite_db, query) |> DataFrame
     results = df[!, 1]
     num_results = length(results)


### PR DESCRIPTION
## Summary

- Adds `ORDER BY id` to the SELECT in `_get_scalar_relation_map` (`src/read.jl:594`).
- Closes #23.

Without `ORDER BY`, SQLite is free to use a covering index for the scan and traverses rows in FK-value order — so the returned relation vector ends up shuffled relative to source-id order. Every other read in this file already orders explicitly; this one was the outlier.

## Test plan

- [x] `Pkg.test()` for PSRDatabase.jl — all existing tests pass
- [x] Repro from #23 now exits clean (`got == expected`)